### PR TITLE
Update Dockerfiles for OpenShift

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -11,9 +11,13 @@ ENV OPERATOR=/usr/local/bin/csi-driver-manila-operator \
 
 COPY --from=0 /go/src/github.com/openshift/csi-driver-manila-operator/csi-driver-manila-operator ${OPERATOR}
 
+COPY deploy/olm-catalog/csi-driver-manila-operator /manifests
+
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+LABEL com.redhat.delivery.appregistry=true
 
 USER ${USER_UID}

--- a/build/Dockerfile.openshift.ci
+++ b/build/Dockerfile.openshift.ci
@@ -11,9 +11,13 @@ ENV OPERATOR=/usr/local/bin/csi-driver-manila-operator \
 
 COPY --from=0 /go/src/github.com/openshift/csi-driver-manila-operator/csi-driver-manila-operator ${OPERATOR}
 
+COPY deploy/olm-catalog/csi-driver-manila-operator /manifests
+
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+LABEL com.redhat.delivery.appregistry=true
 
 USER ${USER_UID}


### PR DESCRIPTION
This patch adds the required label `com.redhat.delivery.appregistry=true` and copies OLM catalog files to /manifests