### PR TITLE
Allow to redefine container images

### DIFF
--- a/deploy/olm-catalog/csi-driver-manila-operator/0.0.1/csi-driver-manila-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/csi-driver-manila-operator/0.0.1/csi-driver-manila-operator.v0.0.1.clusterserviceversion.yaml
@@ -29,6 +29,9 @@ spec:
       version: v1alpha1
   description: Placeholder description
   displayName: Csi Driver Manila Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
   install:
     spec:
       clusterPermissions:
@@ -250,6 +253,16 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: csi-driver-manila-operator
+                - name: EXTERNAL_PROVISIONER_IMAGE
+                  value: quay.io/openshift/origin-csi-external-provisioner:latest
+                - name: EXTERNAL_SNAPSHOTTER_IMAGE
+                  value: quay.io/openshift/origin-csi-external-snapshotter:latest
+                - name: CSI_DRIVER_MANILA_IMAGE
+                  value: quay.io/openshift/origin-csi-driver-manila:latest
+                - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
+                  value: quay.io/openshift/origin-csi-node-driver-registrar:latest
+                - name: CSI_DRIVER_NFS_IMAGE
+                  value: quay.io/openshift/origin-csi-driver-nfs:latest
                 image: quay.io/openshift/origin-csi-driver-manila-operator:latest
                 imagePullPolicy: Always
                 name: csi-driver-manila-operator
@@ -342,6 +355,10 @@ spec:
     type: MultiNamespace
   - supported: true
     type: AllNamespaces
+  keywords:
+  - ""
+  maintainers:
+  - {}
   maturity: alpha
   provider: {}
   replaces: csi-driver-manila-operator.v0.0.0

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,3 +31,13 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "csi-driver-manila-operator"
+            - name: EXTERNAL_PROVISIONER_IMAGE
+              value: "quay.io/openshift/origin-csi-external-provisioner:latest"
+            - name: EXTERNAL_SNAPSHOTTER_IMAGE
+              value: "quay.io/openshift/origin-csi-external-snapshotter:latest"
+            - name: CSI_DRIVER_MANILA_IMAGE
+              value: "quay.io/openshift/origin-csi-driver-manila:latest"
+            - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
+              value: "quay.io/openshift/origin-csi-node-driver-registrar:latest"
+            - name: CSI_DRIVER_NFS_IMAGE
+              value: "quay.io/openshift/origin-csi-driver-nfs:latest"

--- a/pkg/controller/manilacsi/manila_controllerplugin.go
+++ b/pkg/controller/manilacsi/manila_controllerplugin.go
@@ -86,7 +86,7 @@ func generateManilaControllerPluginStatefulSet() *appsv1.StatefulSet {
 								},
 								AllowPrivilegeEscalation: &trueVar,
 							},
-							Image: "quay.io/openshift/origin-csi-external-provisioner:latest",
+							Image: getExternalProvisionerImage(),
 							Args: []string{
 								"--v=5",
 								"--csi-address=$(ADDRESS)",
@@ -116,7 +116,7 @@ func generateManilaControllerPluginStatefulSet() *appsv1.StatefulSet {
 								},
 								AllowPrivilegeEscalation: &trueVar,
 							},
-							Image: "quay.io/openshift/origin-csi-external-snapshotter:latest",
+							Image: getExternalSnaphotterImage(),
 							Args: []string{
 								"--v=5",
 								"--csi-address=$(ADDRESS)",
@@ -146,7 +146,7 @@ func generateManilaControllerPluginStatefulSet() *appsv1.StatefulSet {
 								},
 								AllowPrivilegeEscalation: &trueVar,
 							},
-							Image: "quay.io/openshift/origin-csi-driver-manila:latest",
+							Image: getCSIDriverManilaImage(),
 							Args: []string{
 								"--v=5",
 								"--nodeid=$(NODE_ID)",

--- a/pkg/controller/manilacsi/manila_images.go
+++ b/pkg/controller/manilacsi/manila_images.go
@@ -1,0 +1,54 @@
+package manilacsi
+
+import (
+	"os"
+)
+
+const (
+	defaultExternalProvisionerImage    = "quay.io/openshift/origin-csi-external-provisioner:latest"
+	defaultExternalSnaphotterImage     = "quay.io/openshift/origin-csi-external-snapshotter:latest"
+	defaultCSIDriverManilaImage        = "quay.io/openshift/origin-csi-driver-manila:latest"
+	defaultCSINodeDriverRegistrarImage = "quay.io/openshift/origin-csi-node-driver-registrar:latest"
+	defaultCSIDriverNFSImage           = "quay.io/openshift/origin-csi-driver-nfs:latest"
+
+	externalProvisionerImageEnv    = "EXTERNAL_PROVISIONER_IMAGE"
+	externalSnaphotterImageEnv     = "EXTERNAL_SNAPSHOTTER_IMAGE"
+	csiDriverManilaImageEnv        = "CSI_DRIVER_MANILA_IMAGE"
+	csiNodeDriverRegistrarImageEnv = "CSI_NODE_DRIVER_REGISTRAR_IMAGE"
+	csiDriverNFSImage              = "CSI_DRIVER_NFS_IMAGE"
+)
+
+func getExternalProvisionerImage() string {
+	if externalProvisionerImageFromEnv := os.Getenv(externalProvisionerImageEnv); externalProvisionerImageFromEnv != "" {
+		return externalProvisionerImageFromEnv
+	}
+	return defaultExternalProvisionerImage
+}
+
+func getExternalSnaphotterImage() string {
+	if externalSnaphotterImageFromEnv := os.Getenv(externalSnaphotterImageEnv); externalSnaphotterImageFromEnv != "" {
+		return externalSnaphotterImageFromEnv
+	}
+	return defaultExternalSnaphotterImage
+}
+
+func getCSIDriverManilaImage() string {
+	if csiDriverManilaImageFromEnv := os.Getenv(csiDriverManilaImageEnv); csiDriverManilaImageFromEnv != "" {
+		return csiDriverManilaImageFromEnv
+	}
+	return defaultCSIDriverManilaImage
+}
+
+func getCSINodeDriverRegistrarImage() string {
+	if csiNodeDriverRegistrarImageFromEnv := os.Getenv(csiNodeDriverRegistrarImageEnv); csiNodeDriverRegistrarImageFromEnv != "" {
+		return csiNodeDriverRegistrarImageFromEnv
+	}
+	return defaultCSINodeDriverRegistrarImage
+}
+
+func getCSIDriverNFSImage() string {
+	if csiDriverNFSImageFromEnv := os.Getenv(csiDriverNFSImage); csiDriverNFSImageFromEnv != "" {
+		return csiDriverNFSImageFromEnv
+	}
+	return defaultCSIDriverNFSImage
+}

--- a/pkg/controller/manilacsi/manila_nodeplugin.go
+++ b/pkg/controller/manilacsi/manila_nodeplugin.go
@@ -79,7 +79,7 @@ func generateManilaNodePluginManifest() *appsv1.DaemonSet {
 								},
 								AllowPrivilegeEscalation: &trueVar,
 							},
-							Image: "quay.io/openshift/origin-csi-node-driver-registrar:latest",
+							Image: getCSINodeDriverRegistrarImage(),
 							Args: []string{
 								"--v=5",
 								"--csi-address=/csi/csi.sock",
@@ -128,7 +128,7 @@ func generateManilaNodePluginManifest() *appsv1.DaemonSet {
 								},
 								AllowPrivilegeEscalation: &trueVar,
 							},
-							Image: "quay.io/openshift/origin-csi-driver-manila:latest",
+							Image: getCSIDriverManilaImage(),
 							Args: []string{
 								"--v=5",
 								"--nodeid=$(NODE_ID)",

--- a/pkg/controller/manilacsi/nfs_nodeplugin.go
+++ b/pkg/controller/manilacsi/nfs_nodeplugin.go
@@ -70,7 +70,7 @@ func generateNFSNodePluginManifest() *appsv1.DaemonSet {
 					Containers: []corev1.Container{
 						{
 							Name:  "nfs",
-							Image: "quay.io/openshift/origin-csi-driver-nfs:latest",
+							Image: getCSIDriverNFSImage(),
 							Args: []string{
 								"--nodeid=$(NODE_ID)",
 								"--endpoint=unix://plugin/csi.sock",


### PR DESCRIPTION
This commit adds new env variables to the operator deployment that allow to set alternative images for the components.