### PR TITLE
Bug 1835654: Update CSV manifest

### DIFF
--- a/bundle/manifests/csi-driver-manila-operator.v4.5.0.clusterserviceversion.yaml
+++ b/bundle/manifests/csi-driver-manila-operator.v4.5.0.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: csi-driver-manila-operator.v0.0.1
+  name: csi-driver-manila-operator.v4.5.0
   namespace: openshift-manila-csi-driver-operator
   annotations:
     alm-examples: >-
@@ -15,7 +15,7 @@ metadata:
       container orchestrator.
     containerImage: quay.io/openshift/origin-csi-driver-manila-operator
     support: Red Hat
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     repository: 'https://github.com/openshift/csi-driver-manila-operator'
 spec:
   displayName: CSI Driver Manila Operator
@@ -34,15 +34,17 @@ spec:
     provisioning of RWX persistent volumes on OpenStack.
 
   maturity: alpha
-  version: 0.0.1
+  version: 4.5.0
   replaces: ''
   skips: []
-  minKubeVersion: 1.14.0
+  minKubeVersion: 1.17.0
   keywords:
     - OpenStack Manila
     - Manila CSI
     - CSI
   maintainers:
+    - name: Red Hat
+      email: aos-storage-staff@redhat.com
     - name: OpenShift ShiftStack Team
       email: shiftstack-team@redhat.com
   provider:

--- a/bundle/manifests/csi-driver-manila-operator.v4.5.0.clusterserviceversion.yaml
+++ b/bundle/manifests/csi-driver-manila-operator.v4.5.0.clusterserviceversion.yaml
@@ -453,9 +453,9 @@ spec:
                 serviceAccountName: csi-driver-manila-operator
   installModes:
     - type: OwnNamespace
-      supported: true
+      supported: false
     - type: SingleNamespace
-      supported: true
+      supported: false
     - type: MultiNamespace
       supported: false
     - type: AllNamespaces

--- a/bundle/manifests/csi-driver-manila-operator.v4.5.0.clusterserviceversion.yaml
+++ b/bundle/manifests/csi-driver-manila-operator.v4.5.0.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
     support: Red Hat
     capabilities: Seamless Upgrades
     repository: 'https://github.com/openshift/csi-driver-manila-operator'
+    "operatorframework.io/suggested-namespace": openshift-manila-csi-driver-operator
 spec:
   displayName: CSI Driver Manila Operator
   description: >+

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "4.5.0"
 )


### PR DESCRIPTION
This commit:
1. Changes Operator version from 0.0.1 to 4.5.0 to comply with OpenShift requirements.
2. Sets capabilities to Seamless Upgrades.
3. Adds aos-storage-staff to the list of maintainers.
4. Bumps minKubeVersion to 1.17.0