### PR TITLE
Change image for example pods

### DIFF
--- a/examples/nfs/dynamic-provisioning/pod.yaml
+++ b/examples/nfs/dynamic-provisioning/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: hello-manila
-      image: gcr.io/hello-minikube-zero-install/hello-node
+      image: docker.io/library/nginx
       ports:
         - containerPort: 8080
       volumeMounts:

--- a/examples/nfs/static-provisioning/pod.yaml
+++ b/examples/nfs/static-provisioning/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: hello-manila
-      image: gcr.io/hello-minikube-zero-install/hello-node
+      image: docker.io/library/nginx
       ports:
         - containerPort: 8080
       volumeMounts:


### PR DESCRIPTION
gcr.io/hello-minikube-zero-install/hello-node doesn't exist anymore,
we started using more stable docker.io/library/nginx for example
pods.