### PR TITLE
Bug 1837210: Separate operator and driver namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: csi-manila-secrets
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver
 stringData:
   # Mandatory
   os-authURL: "http://example.com/identity"

--- a/bundle/manifests/csi-driver-manila-operator.v0.0.1.clusterserviceversion.yaml
+++ b/bundle/manifests/csi-driver-manila-operator.v0.0.1.clusterserviceversion.yaml
@@ -2,10 +2,10 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: csi-driver-manila-operator.v0.0.1
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
   annotations:
     alm-examples: >-
-      [{"apiVersion":"csi.openshift.io/v1alpha1","kind":"ManilaDriver","metadata":{"name":"example-manilacsi","namespace":"manila-csi"}},{"apiVersion":"csi.openshift.io/v1alpha1","kind":"ManilaDriver","metadata":{"name":"example-manilacsi","namespace":"manila-csi"}}]
+      [{"apiVersion":"csi.openshift.io/v1alpha1","kind":"ManilaDriver","metadata":{"name":"example-manilacsi","namespace":"openshift-manila-csi-driver-operator"}},{"apiVersion":"csi.openshift.io/v1alpha1","kind":"ManilaDriver","metadata":{"name":"example-manilacsi","namespace":"openshift-manila-csi-driver-operator"}}]
     categories: Storage
     certified: 'false'
     createdAt: 'Tue Mar 17 17:27:30 CET 2020'
@@ -168,6 +168,40 @@ spec:
       clusterPermissions:
         - rules:
             - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - services/finalizers
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - storage.k8s.io
               resources:
                 - csidrivers
@@ -254,6 +288,9 @@ spec:
               verbs:
                 - get
                 - list
+                - create
+                - delete
+                - watch
             - apiGroups:
                 - ''
               resources:

--- a/deploy/crds/csi.openshift.io_v1alpha1_maniladriver_cr.yaml
+++ b/deploy/crds/csi.openshift.io_v1alpha1_maniladriver_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: csi.openshift.io/v1alpha1
 kind: ManilaDriver
 metadata:
   name: example-manilacsi
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
 spec:
   # Add fields here
   size: 3

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: manila-csi
+  name: openshift-manila-csi-driver-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: csi-driver-manila-operator
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
 spec:
   replicas: 1
   selector:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: csi-driver-manila-operator
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
 rules:
 - apiGroups:
   - ""
@@ -86,6 +86,40 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-driver-manila-operator
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:
@@ -173,6 +207,9 @@ rules:
   verbs:
     - get
     - list
+    - create
+    - delete
+    - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -2,14 +2,14 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-driver-manila-operator
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
 subjects:
 - kind: ServiceAccount
   name: csi-driver-manila-operator
 roleRef:
   kind: Role
   name: csi-driver-manila-operator
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -20,7 +20,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: csi-driver-manila-operator
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator
 roleRef:
   kind: ClusterRole
   name: csi-driver-manila-operator

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-driver-manila-operator
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver-operator

--- a/examples/nfs/dynamic-provisioning/storageclass.yaml
+++ b/examples/nfs/dynamic-provisioning/storageclass.yaml
@@ -8,8 +8,8 @@ parameters:
   type: default
   
   csi.storage.k8s.io/provisioner-secret-name: csi-manila-secrets
-  csi.storage.k8s.io/provisioner-secret-namespace: manila-csi
+  csi.storage.k8s.io/provisioner-secret-namespace: openshift-manila-csi-driver
   csi.storage.k8s.io/node-stage-secret-name: csi-manila-secrets
-  csi.storage.k8s.io/node-stage-secret-namespace: manila-csi
+  csi.storage.k8s.io/node-stage-secret-namespace: openshift-manila-csi-driver
   csi.storage.k8s.io/node-publish-secret-name: csi-manila-secrets
-  csi.storage.k8s.io/node-publish-secret-namespace: manila-csi
+  csi.storage.k8s.io/node-publish-secret-namespace: openshift-manila-csi-driver

--- a/examples/nfs/secrets.yaml
+++ b/examples/nfs/secrets.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: csi-manila-secrets
-  namespace: manila-csi
+  namespace: openshift-manila-csi-driver
 stringData:
   # Mandatory
   os-authURL: "some-auth-url"

--- a/examples/nfs/snapshot/snapshotclass.yaml
+++ b/examples/nfs/snapshot/snapshotclass.yaml
@@ -5,4 +5,4 @@ metadata:
 snapshotter: manila.csi.openstack.org
 parameters:
   csi.storage.k8s.io/snapshotter-secret-name: csi-manila-secrets
-  csi.storage.k8s.io/snapshotter-secret-namespace: manila-csi
+  csi.storage.k8s.io/snapshotter-secret-namespace: openshift-manila-csi-driver

--- a/examples/nfs/static-provisioning/preprovisioned-pvc.yaml
+++ b/examples/nfs/static-provisioning/preprovisioned-pvc.yaml
@@ -14,10 +14,10 @@ spec:
     volumeHandle: preprovisioned-nfs-share
     nodeStageSecretRef:
       name: csi-manila-secrets
-      namespace: manila-csi
+      namespace: openshift-manila-csi-driver
     nodePublishSecretRef:
       name: csi-manila-secrets
-      namespace: manila-csi
+      namespace: openshift-manila-csi-driver
     volumeAttributes:
       shareID: SHARE-UUID-GOES-HERE
       shareAccessID: ACCESS-UUID-OF-THE-SHARE

--- a/pkg/controller/maniladriver/manila_controllerplugin_rbac.go
+++ b/pkg/controller/maniladriver/manila_controllerplugin_rbac.go
@@ -63,14 +63,14 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginServiceAccount(insta
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstack-manila-csi-controllerplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsManilaControllerPlugin,
 		},
 	}
 
 	// Check if this ServiceAccount already exists
 	found := &corev1.ServiceAccount{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ServiceAccount", "ServiceAccount.Namespace", sa.Namespace, "ServiceAccount.Name", sa.Name)
 		err = r.client.Create(context.TODO(), sa)
@@ -179,7 +179,7 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginClusterRole(instance
 
 	// Check if this ClusterRole already exists
 	found := &rbacv1.ClusterRole{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: cr.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: cr.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRole", "ClusterRole.Name", cr.Name)
 		err = r.client.Create(context.TODO(), cr)
@@ -226,7 +226,7 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginClusterRoleBinding(i
 			{
 				Kind:      "ServiceAccount",
 				Name:      "openstack-manila-csi-controllerplugin",
-				Namespace: "manila-csi",
+				Namespace: "openshift-manila-csi-driver",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -238,7 +238,7 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginClusterRoleBinding(i
 
 	// Check if this ClusterRoleBinding already exists
 	found := &rbacv1.ClusterRoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: crb.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: crb.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRoleBinding", "ClusterRoleBinding.Name", crb.Name)
 		err = r.client.Create(context.TODO(), crb)
@@ -279,7 +279,7 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginRole(instance *manil
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstack-manila-csi-controllerplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsManilaControllerPlugin,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -298,7 +298,7 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginRole(instance *manil
 
 	// Check if this Role already exists
 	found := &rbacv1.Role{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new Role", "Role.Namespace", role.Namespace, "Role.Name", role.Name)
 		err = r.client.Create(context.TODO(), role)
@@ -339,14 +339,14 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginRoleBinding(instance
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstack-manila-csi-controllerplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsManilaControllerPlugin,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      "openstack-manila-csi-controllerplugin",
-				Namespace: "manila-csi",
+				Namespace: "openshift-manila-csi-driver",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -358,7 +358,7 @@ func (r *ReconcileManilaDriver) handleManilaControllerPluginRoleBinding(instance
 
 	// Check if this RoleBinding already exists
 	found := &rbacv1.RoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new RoleBinding", "RoleBinding.Namespace", rb.Namespace, "RoleBinding.Name", rb.Name)
 		err = r.client.Create(context.TODO(), rb)

--- a/pkg/controller/maniladriver/manila_credentials.go
+++ b/pkg/controller/maniladriver/manila_credentials.go
@@ -17,7 +17,7 @@ const (
 	cloudsSecretKey     = "clouds.yaml"
 	installerSecretName = "installer-cloud-credentials"
 	driverSecretName    = "csi-manila-secrets"
-	secretNamespace     = "manila-csi"
+	secretNamespace     = "openshift-manila-csi-driver"
 	cloudName           = "openstack"
 )
 
@@ -28,7 +28,7 @@ func (r *ReconcileManilaDriver) createDriverCredentialsSecret(instance *maniladr
 	secret := generateSecret(cloudConfig)
 
 	found := &corev1.Secret{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: driverSecretName, Namespace: secretNamespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: driverSecretName, Namespace: secretNamespace}, found)
 	if err == nil {
 		// Check if we need to update the object
 		patchResult, err := patch.DefaultPatchMaker.Calculate(found, secret)

--- a/pkg/controller/maniladriver/manila_csidriver.go
+++ b/pkg/controller/maniladriver/manila_csidriver.go
@@ -34,7 +34,7 @@ func (r *ReconcileManilaDriver) handleManilaCSIDriver(instance *maniladriverv1al
 
 	// Check if this CSIDriver already exists
 	found := &storagev1beta1.CSIDriver{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: driver.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: driver.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new CSIDriver", "CSIDriver.Name", driver.Name)
 		err = r.client.Create(context.TODO(), driver)

--- a/pkg/controller/maniladriver/manila_driver_namespace.go
+++ b/pkg/controller/maniladriver/manila_driver_namespace.go
@@ -1,0 +1,42 @@
+package maniladriver
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	maniladriverv1alpha1 "github.com/openshift/csi-driver-manila-operator/pkg/apis/maniladriver/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (r *ReconcileManilaDriver) handleManilaDriverNamespace(instance *maniladriverv1alpha1.ManilaDriver, reqLogger logr.Logger) error {
+	reqLogger.Info("Reconciling Manila Driver Namespace")
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-manila-csi-driver",
+		},
+	}
+
+	// Check if this Namespace already exists
+	found := &corev1.Namespace{}
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: ns.Name, Namespace: ""}, found)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Namespace", "Namespace.Name", ns.Name)
+		err = r.client.Create(context.TODO(), ns)
+		if err != nil {
+			return err
+		}
+
+		// Namespace created successfully - don't requeue
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// Namespace already exists - don't requeue
+	reqLogger.Info("Skip reconcile: Namespace already exists", "Namespace.Name", found.Name)
+	return nil
+}

--- a/pkg/controller/maniladriver/manila_nodeplugin.go
+++ b/pkg/controller/maniladriver/manila_nodeplugin.go
@@ -21,7 +21,7 @@ func (r *ReconcileManilaDriver) handleManilaNodePluginDaemonSet(instance *manila
 
 	// Check if this DaemonSet already exists
 	found := &appsv1.DaemonSet{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new DaemonSet", "DaemonSet.Namespace", ds.Namespace, "DaemonSet.Name", ds.Name)
 		err = r.client.Create(context.TODO(), ds)
@@ -69,7 +69,7 @@ func generateManilaNodePluginManifest() *appsv1.DaemonSet {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstack-manila-csi-nodeplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsManilaNodePlugin,
 		},
 		Spec: appsv1.DaemonSetSpec{

--- a/pkg/controller/maniladriver/manila_nodeplugin_rbac.go
+++ b/pkg/controller/maniladriver/manila_nodeplugin_rbac.go
@@ -51,14 +51,14 @@ func (r *ReconcileManilaDriver) handleManilaNodePluginServiceAccount(instance *m
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstack-manila-csi-nodeplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsManilaNodePlugin,
 		},
 	}
 
 	// Check if this ServiceAccount already exists
 	found := &corev1.ServiceAccount{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ServiceAccount", "ServiceAccount.Namespace", sa.Namespace, "ServiceAccount.Name", sa.Name)
 		err = r.client.Create(context.TODO(), sa)
@@ -127,7 +127,7 @@ func (r *ReconcileManilaDriver) handleManilaNodePluginClusterRole(instance *mani
 
 	// Check if this ClusterRole already exists
 	found := &rbacv1.ClusterRole{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: cr.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: cr.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRole", "ClusterRole.Name", cr.Name)
 		err = r.client.Create(context.TODO(), cr)
@@ -174,7 +174,7 @@ func (r *ReconcileManilaDriver) handleManilaNodePluginClusterRoleBinding(instanc
 			{
 				Kind:      "ServiceAccount",
 				Name:      "openstack-manila-csi-nodeplugin",
-				Namespace: "manila-csi",
+				Namespace: "openshift-manila-csi-driver",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -186,7 +186,7 @@ func (r *ReconcileManilaDriver) handleManilaNodePluginClusterRoleBinding(instanc
 
 	// Check if this ClusterRoleBinding already exists
 	found := &rbacv1.ClusterRoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: crb.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: crb.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRoleBinding", "ClusterRoleBinding.Name", crb.Name)
 		err = r.client.Create(context.TODO(), crb)

--- a/pkg/controller/maniladriver/manila_storageclasses.go
+++ b/pkg/controller/maniladriver/manila_storageclasses.go
@@ -43,17 +43,17 @@ func (r *ReconcileManilaDriver) handleManilaStorageClass(instance *maniladriverv
 		Parameters: map[string]string{
 			"type": shareType.Name,
 			"csi.storage.k8s.io/provisioner-secret-name":       "csi-manila-secrets",
-			"csi.storage.k8s.io/provisioner-secret-namespace":  "manila-csi",
+			"csi.storage.k8s.io/provisioner-secret-namespace":  "openshift-manila-csi-driver",
 			"csi.storage.k8s.io/node-stage-secret-name":        "csi-manila-secrets",
-			"csi.storage.k8s.io/node-stage-secret-namespace":   "manila-csi",
+			"csi.storage.k8s.io/node-stage-secret-namespace":   "openshift-manila-csi-driver",
 			"csi.storage.k8s.io/node-publish-secret-name":      "csi-manila-secrets",
-			"csi.storage.k8s.io/node-publish-secret-namespace": "manila-csi",
+			"csi.storage.k8s.io/node-publish-secret-namespace": "openshift-manila-csi-driver",
 		},
 	}
 
 	// Check if this StorageClass already exists
 	found := &storagev1.StorageClass{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: ""}, found)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/controller/maniladriver/nfs_nodeplugin.go
+++ b/pkg/controller/maniladriver/nfs_nodeplugin.go
@@ -21,7 +21,7 @@ func (r *ReconcileManilaDriver) handleNFSNodePluginDaemonSet(instance *maniladri
 
 	// Check if this DaemonSet already exists
 	found := &appsv1.DaemonSet{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new DaemonSet", "DaemonSet.Namespace", ds.Namespace, "DaemonSet.Name", ds.Name)
 		err = r.client.Create(context.TODO(), ds)
@@ -71,7 +71,7 @@ func generateNFSNodePluginManifest() *appsv1.DaemonSet {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "csi-nodeplugin-nfsplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsNFSNodePlugin,
 		},
 		Spec: appsv1.DaemonSetSpec{

--- a/pkg/controller/maniladriver/nfs_nodeplugin_rbac.go
+++ b/pkg/controller/maniladriver/nfs_nodeplugin_rbac.go
@@ -51,14 +51,14 @@ func (r *ReconcileManilaDriver) handleNFSNodePluginServiceAccount(instance *mani
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "csi-nodeplugin",
-			Namespace: "manila-csi",
+			Namespace: "openshift-manila-csi-driver",
 			Labels:    labelsNFSNodePlugin,
 		},
 	}
 
 	// Check if this ServiceAccount already exists
 	found := &corev1.ServiceAccount{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ServiceAccount", "ServiceAccount.Namespace", sa.Namespace, "ServiceAccount.Name", sa.Name)
 		err = r.client.Create(context.TODO(), sa)
@@ -122,7 +122,7 @@ func (r *ReconcileManilaDriver) handleNFSNodePluginClusterRole(instance *manilad
 
 	// Check if this ClusterRole already exists
 	found := &rbacv1.ClusterRole{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: cr.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: cr.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRole", "ClusterRole.Name", cr.Name)
 		err = r.client.Create(context.TODO(), cr)
@@ -169,7 +169,7 @@ func (r *ReconcileManilaDriver) handleNFSNodePluginClusterRoleBinding(instance *
 			{
 				Kind:      "ServiceAccount",
 				Name:      "csi-nodeplugin",
-				Namespace: "manila-csi",
+				Namespace: "openshift-manila-csi-driver",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -181,7 +181,7 @@ func (r *ReconcileManilaDriver) handleNFSNodePluginClusterRoleBinding(instance *
 
 	// Check if this ClusterRoleBinding already exists
 	found := &rbacv1.ClusterRoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: crb.Name, Namespace: ""}, found)
+	err := r.apiReader.Get(context.TODO(), types.NamespacedName{Name: crb.Name, Namespace: ""}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRoleBinding", "ClusterRoleBinding.Name", crb.Name)
 		err = r.client.Create(context.TODO(), crb)


### PR DESCRIPTION
By default now Manila operator lives in "openshift-manila-csi-driver-operator" and all the driver's components are located in "openshift-manila-csi-driver".

Previously they were in "manila-csi".