### PR TITLE
Change operand namespace

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -2,7 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: manila-csi-driver-controller
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -1,18 +1,20 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: manila-csi-driver-controller
+  name: openstack-manila-csi-controllerplugin
   namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
-      app: manila-csi-driver-controller
+      app: openstack-manila-csi
+      component: controllerplugin
   serviceName: manila-csi-driver-controller
   replicas: 1
   template:
     metadata:
       labels:
-        app: manila-csi-driver-controller
+        app: openstack-manila-csi
+        component: controllerplugin
     spec:
       serviceAccount: manila-csi-driver-controller-sa
       priorityClassName: system-cluster-critical

--- a/assets/controller_sa.yaml
+++ b/assets/controller_sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: manila-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -1,16 +1,18 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: manila-csi-driver-node
+  name: openstack-manila-csi-nodeplugin
   namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
-      app: manila-csi-driver-node
+      app: openstack-manila-csi
+      component: nodeplugin
   template:
     metadata:
       labels:
-        app: manila-csi-driver-node
+        app: openstack-manila-csi
+        component: nodeplugin
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -2,7 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: manila-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:

--- a/assets/node_nfs.yaml
+++ b/assets/node_nfs.yaml
@@ -2,7 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: manila-csi-driver-node-nfs
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:

--- a/assets/node_nfs.yaml
+++ b/assets/node_nfs.yaml
@@ -1,16 +1,18 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: manila-csi-driver-node-nfs
+  name: csi-nodeplugin-nfsplugin
   namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
-      app: manila-csi-driver-node-nfs
+      app: openstack-manila-csi
+      component: nfs-nodeplugin
   template:
     metadata:
       labels:
-        app: manila-csi-driver-node-nfs
+        app: openstack-manila-csi
+        component: nfs-nodeplugin
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/assets/node_sa.yaml
+++ b/assets/node_sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: manila-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver

--- a/assets/rbac/controller_privileged_binding.yaml
+++ b/assets/rbac/controller_privileged_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-privileged-role

--- a/assets/rbac/node_privileged_binding.yaml
+++ b/assets/rbac/node_privileged_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-node-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-privileged-role

--- a/assets/rbac/provisioner_binding.yaml
+++ b/assets/rbac/provisioner_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-external-provisioner-role

--- a/assets/rbac/snapshotter_binding.yaml
+++ b/assets/rbac/snapshotter_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-external-snapshotter-role

--- a/manifests/09_credentials.yaml
+++ b/manifests/09_credentials.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-manila-csi-driver
+  name: openshift-manila-csi-driver-operator
   namespace: openshift-cloud-credential-operator
 spec:
   secretRef:

--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -145,7 +145,7 @@ func (c *ManilaController) applyStorageClass(ctx context.Context, expected *stor
 func (c *ManilaController) generateStorageClass(shareType sharetypes.ShareType) *storagev1.StorageClass {
 	storageClassName := util.StorageClassNamePrefix + shareType.Name
 	delete := corev1.PersistentVolumeReclaimDelete
-	waitForFirstConsumer := storagev1.VolumeBindingWaitForFirstConsumer
+	immediate := storagev1.VolumeBindingImmediate
 	sc := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: storageClassName,
@@ -161,7 +161,7 @@ func (c *ManilaController) generateStorageClass(shareType sharetypes.ShareType) 
 			"csi.storage.k8s.io/node-publish-secret-namespace": util.OperandNamespace,
 		},
 		ReclaimPolicy:     &delete,
-		VolumeBindingMode: &waitForFirstConsumer,
+		VolumeBindingMode: &immediate,
 	}
 	return sc
 }

--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -2,7 +2,6 @@ package manila
 
 import (
 	"context"
-	"reflect"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -12,11 +11,9 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
@@ -132,7 +129,7 @@ func (c *ManilaController) syncStorageClasses(ctx context.Context, shareTypes []
 	for _, shareType := range shareTypes {
 		klog.V(4).Infof("Syncing storage class for shareType type %s", shareType.Name)
 		sc := c.generateStorageClass(shareType)
-		err := c.applyStorageClass(ctx, sc)
+		_, _, err := resourceapply.ApplyStorageClass(c.kubeClient.StorageV1(), c.eventRecorder, sc)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -141,27 +138,7 @@ func (c *ManilaController) syncStorageClasses(ctx context.Context, shareTypes []
 }
 
 func (c *ManilaController) applyStorageClass(ctx context.Context, expected *storagev1.StorageClass) error {
-	current, err := c.storageClassLister.Get(expected.Name)
-	if err == nil {
-		if !reflect.DeepEqual(expected.Parameters, current.Parameters) {
-			// StorageClass.Parameters changed. Typically, secret namespace
-			// is different when moving from OLM to non-OLM operator.
-			// Delete the old class and create a new one.
-			if err := c.kubeClient.StorageV1().StorageClasses().Delete(ctx, expected.Name, metav1.DeleteOptions{}); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return err
-				}
-				// Fall through to ApplyStorageClass below on IsNotFound error to create a new SC.
-			}
-			// Merge existing and expected ObjectMeta (esp. default storage class)
-			var modified bool
-			currentCopy := current.DeepCopy()
-			resourcemerge.EnsureObjectMeta(&modified, &currentCopy.ObjectMeta, expected.ObjectMeta)
-			expected.ObjectMeta = currentCopy.ObjectMeta
-			// Fall through to ApplyStorageClass, it will create a new class.
-		}
-	}
-	_, _, err = resourceapply.ApplyStorageClass(c.kubeClient.StorageV1(), c.eventRecorder, expected)
+	_, _, err := resourceapply.ApplyStorageClass(c.kubeClient.StorageV1(), c.eventRecorder, expected)
 	return err
 }
 
@@ -177,11 +154,11 @@ func (c *ManilaController) generateStorageClass(shareType sharetypes.ShareType) 
 		Parameters: map[string]string{
 			"type": shareType.Name,
 			"csi.storage.k8s.io/provisioner-secret-name":       util.ManilaSecretName,
-			"csi.storage.k8s.io/provisioner-secret-namespace":  util.OperatorNamespace,
+			"csi.storage.k8s.io/provisioner-secret-namespace":  util.OperandNamespace,
 			"csi.storage.k8s.io/node-stage-secret-name":        util.ManilaSecretName,
-			"csi.storage.k8s.io/node-stage-secret-namespace":   util.OperatorNamespace,
+			"csi.storage.k8s.io/node-stage-secret-namespace":   util.OperandNamespace,
 			"csi.storage.k8s.io/node-publish-secret-name":      util.ManilaSecretName,
-			"csi.storage.k8s.io/node-publish-secret-namespace": util.OperatorNamespace,
+			"csi.storage.k8s.io/node-publish-secret-namespace": util.OperandNamespace,
 		},
 		ReclaimPolicy:     &delete,
 		VolumeBindingMode: &waitForFirstConsumer,

--- a/pkg/controllers/secret/secretsync.go
+++ b/pkg/controllers/secret/secretsync.go
@@ -44,8 +44,8 @@ func NewSecretSyncController(
 	resync time.Duration,
 	eventRecorder events.Recorder) factory.Controller {
 
-	// Produce secrets in the operator namespace
-	secretInformer := informers.InformersFor(util.OperatorNamespace)
+	// Produce secrets in the operand namespace
+	secretInformer := informers.InformersFor(util.OperandNamespace)
 	c := &SecretSyncController{
 		operatorClient: operatorClient,
 		kubeClient:     kubeClient,
@@ -67,7 +67,7 @@ func (c *SecretSyncController) sync(ctx context.Context, syncCtx factory.SyncCon
 		return nil
 	}
 
-	cloudSecret, err := c.secretLister.Secrets(util.OperatorNamespace).Get(util.CloudCredentialSecretName)
+	cloudSecret, err := c.secretLister.Secrets(util.OperandNamespace).Get(util.CloudCredentialSecretName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// TODO: report error after some while?
@@ -151,7 +151,7 @@ func (c *SecretSyncController) translateSecret(cloudSecret *v1.Secret) (*v1.Secr
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.ManilaSecretName,
-			Namespace: util.OperatorNamespace,
+			Namespace: util.OperandNamespace,
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: data,

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -71,18 +71,20 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _controllerYaml = []byte(`kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: manila-csi-driver-controller
+  name: openstack-manila-csi-controllerplugin
   namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
-      app: manila-csi-driver-controller
+      app: openstack-manila-csi
+      component: controllerplugin
   serviceName: manila-csi-driver-controller
   replicas: 1
   template:
     metadata:
       labels:
-        app: manila-csi-driver-controller
+        app: openstack-manila-csi
+        component: controllerplugin
     spec:
       serviceAccount: manila-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
@@ -321,16 +323,18 @@ func namespaceYaml() (*asset, error) {
 var _nodeYaml = []byte(`kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: manila-csi-driver-node
+  name: openstack-manila-csi-nodeplugin
   namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
-      app: manila-csi-driver-node
+      app: openstack-manila-csi
+      component: nodeplugin
   template:
     metadata:
       labels:
-        app: manila-csi-driver-node
+        app: openstack-manila-csi
+        component: nodeplugin
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -453,16 +457,18 @@ func nodeYaml() (*asset, error) {
 var _node_nfsYaml = []byte(`kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: manila-csi-driver-node-nfs
+  name: csi-nodeplugin-nfsplugin
   namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
-      app: manila-csi-driver-node-nfs
+      app: openstack-manila-csi
+      component: nfs-nodeplugin
   template:
     metadata:
       labels:
-        app: manila-csi-driver-node-nfs
+        app: openstack-manila-csi
+        component: nfs-nodeplugin
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -2,7 +2,9 @@
 // sources:
 // assets/controller.yaml
 // assets/controller_sa.yaml
+// assets/credentials.yaml
 // assets/csidriver.yaml
+// assets/namespace.yaml
 // assets/node.yaml
 // assets/node_nfs.yaml
 // assets/node_sa.yaml
@@ -70,7 +72,7 @@ var _controllerYaml = []byte(`kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: manila-csi-driver-controller
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
@@ -221,7 +223,7 @@ var _controller_saYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: manila-csi-driver-controller-sa
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 `)
 
 func controller_saYamlBytes() ([]byte, error) {
@@ -235,6 +237,35 @@ func controller_saYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "controller_sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _credentialsYaml = []byte(`apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-manila-csi-driver
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: manila-cloud-credentials
+    namespace: openshift-manila-csi-driver
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OpenStackProviderSpec
+`)
+
+func credentialsYamlBytes() ([]byte, error) {
+	return _credentialsYaml, nil
+}
+
+func credentialsYaml() (*asset, error) {
+	bytes, err := credentialsYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "credentials.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -266,11 +297,32 @@ func csidriverYaml() (*asset, error) {
 	return a, nil
 }
 
+var _namespaceYaml = []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-manila-csi-driver
+`)
+
+func namespaceYamlBytes() ([]byte, error) {
+	return _namespaceYaml, nil
+}
+
+func namespaceYaml() (*asset, error) {
+	bytes, err := namespaceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "namespace.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _nodeYaml = []byte(`kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: manila-csi-driver-node
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
@@ -402,7 +454,7 @@ var _node_nfsYaml = []byte(`kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: manila-csi-driver-node-nfs
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   selector:
     matchLabels:
@@ -473,7 +525,7 @@ var _node_saYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: manila-csi-driver-node-sa
-  namespace: openshift-cluster-csi-drivers`)
+  namespace: openshift-manila-csi-driver`)
 
 func node_saYamlBytes() ([]byte, error) {
 	return _node_saYaml, nil
@@ -497,7 +549,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-privileged-role
@@ -526,7 +578,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-node-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-privileged-role
@@ -581,7 +633,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-external-provisioner-role
@@ -650,7 +702,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-external-snapshotter-role
@@ -781,7 +833,9 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"controller.yaml":    controllerYaml,
 	"controller_sa.yaml": controller_saYaml,
+	"credentials.yaml":   credentialsYaml,
 	"csidriver.yaml":     csidriverYaml,
+	"namespace.yaml":     namespaceYaml,
 	"node.yaml":          nodeYaml,
 	"node_nfs.yaml":      node_nfsYaml,
 	"node_sa.yaml":       node_saYaml,
@@ -837,7 +891,9 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"controller.yaml":    {controllerYaml, map[string]*bintree{}},
 	"controller_sa.yaml": {controller_saYaml, map[string]*bintree{}},
+	"credentials.yaml":   {credentialsYaml, map[string]*bintree{}},
 	"csidriver.yaml":     {csidriverYaml, map[string]*bintree{}},
+	"namespace.yaml":     {namespaceYaml, map[string]*bintree{}},
 	"node.yaml":          {nodeYaml, map[string]*bintree{}},
 	"node_nfs.yaml":      {node_nfsYaml, map[string]*bintree{}},
 	"node_sa.yaml":       {node_saYaml, map[string]*bintree{}},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -35,7 +35,7 @@ const (
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
 	kubeClient := kubeclient.NewForConfigOrDie(rest.AddUserAgent(controllerConfig.KubeConfig, operatorName))
-	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperatorNamespace, "")
+	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperandNamespace, "")
 
 	// Create GenericOperatorclient. This is used by controllers created down below
 	gvr := operatorapi.SchemeGroupVersion.WithResource("clustercsidrivers")
@@ -56,6 +56,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces,
 		generated.Asset,
 		[]string{
+			"namespace.yaml",
 			"csidriver.yaml",
 			"controller_sa.yaml",
 			"node_sa.yaml",
@@ -71,10 +72,10 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		"ManilaDriverController",
 		factory.DefaultQueueKey,
 		operandName,
-		util.OperatorNamespace,
+		util.OperandNamespace,
 		assetWithNFSDriver,
 		kubeClient,
-		kubeInformersForNamespaces.InformersFor(util.OperatorNamespace),
+		kubeInformersForNamespaces.InformersFor(util.OperandNamespace),
 		csicontrollerset.WithControllerService("controller.yaml"),
 		csicontrollerset.WithNodeService("node.yaml"),
 	)
@@ -82,13 +83,13 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	nfsCSIDriverController := csidrivercontroller.NewCSIDriverController(
 		"NFSDriverController",
 		"nfs-csi-driver",
-		util.OperatorNamespace,
+		util.OperandNamespace,
 		string(operatorapi.ManilaCSIDriver),
 		operatorClient,
 		assetWithNFSDriver,
 		kubeClient,
 		controllerConfig.EventRecorder,
-	).WithNodeService(kubeInformersForNamespaces.InformersFor(util.OperatorNamespace).Apps().V1().DaemonSets(), "node_nfs.yaml")
+	).WithNodeService(kubeInformersForNamespaces.InformersFor(util.OperandNamespace).Apps().V1().DaemonSets(), "node_nfs.yaml")
 
 	openstackClient, err := manila.NewOpenStackClient(util.CloudConfigFilename, kubeInformersForNamespaces)
 	if err != nil {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -1,7 +1,7 @@
 package util
 
 const (
-	OperatorNamespace         = "openshift-cluster-csi-drivers"
+	OperandNamespace          = "openshift-manila-csi-driver"
 	CloudCredentialSecretName = "manila-cloud-credentials"
 	ManilaSecretName          = "manila-driver-credentials"
 

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -3,7 +3,7 @@ package util
 const (
 	OperandNamespace          = "openshift-manila-csi-driver"
 	CloudCredentialSecretName = "manila-cloud-credentials"
-	ManilaSecretName          = "manila-driver-credentials"
+	ManilaSecretName          = "csi-manila-secrets"
 
 	CloudConfigNamespace = "openshift-config"
 	CloudConfigName      = "cloud-provider-config"

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -5,6 +5,9 @@ const (
 	CloudCredentialSecretName = "manila-cloud-credentials"
 	ManilaSecretName          = "manila-driver-credentials"
 
+	CloudConfigNamespace = "openshift-config"
+	CloudConfigName      = "cloud-provider-config"
+
 	StorageClassNamePrefix = "csi-manila-"
 
 	// OpenStack config file name (as present in the operator Deployment)

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -1,0 +1,67 @@
+package resourcesynccontroller
+
+import (
+	"crypto/x509"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+	certificates := []*x509.Certificate{}
+	for _, input := range inputConfigMaps {
+		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// configmaps must conform to this
+		inputContent := inputConfigMap.Data["ca-bundle.crt"]
+		if len(inputContent) == 0 {
+			continue
+		}
+		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))
+		if err != nil {
+			return nil, fmt.Errorf("configmap/%s in %q is malformed: %v", input.Name, input.Namespace, err)
+		}
+		certificates = append(certificates, inputCerts...)
+	}
+
+	certificates = crypto.FilterExpiredCerts(certificates...)
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: destinationConfigMap.Namespace, Name: destinationConfigMap.Name},
+		Data: map[string]string{
+			"ca-bundle.crt": string(caBytes),
+		},
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,0 +1,19 @@
+package resourcesynccontroller
+
+// ResourceLocation describes coordinates for a resource to be synced
+type ResourceLocation struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+var emptyResourceLocation = ResourceLocation{}
+
+// ResourceSyncer allows changes to syncing rules by this controller
+type ResourceSyncer interface {
+	// SyncConfigMap indicates that a configmap should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncConfigMap(destination, source ResourceLocation) error
+	// SyncSecret indicates that a secret should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncSecret(destination, source ResourceLocation) error
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -1,0 +1,280 @@
+package resourcesynccontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
+// It will also mirror deletions by deleting destinations.
+type ResourceSyncController struct {
+	name string
+	// syncRuleLock is used to ensure we avoid races on changes to syncing rules
+	syncRuleLock sync.RWMutex
+	// configMapSyncRules is a map from destination location to source location
+	configMapSyncRules map[ResourceLocation]ResourceLocation
+	// secretSyncRules is a map from destination location to source location
+	secretSyncRules map[ResourceLocation]ResourceLocation
+
+	// knownNamespaces is the list of namespaces we are watching.
+	knownNamespaces sets.String
+
+	configMapGetter            corev1client.ConfigMapsGetter
+	secretGetter               corev1client.SecretsGetter
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	operatorConfigClient       v1helpers.OperatorClient
+
+	runFn   func(ctx context.Context, workers int)
+	syncCtx factory.SyncContext
+}
+
+var _ ResourceSyncer = &ResourceSyncController{}
+var _ factory.Controller = &ResourceSyncController{}
+
+// NewResourceSyncController creates ResourceSyncController.
+func NewResourceSyncController(
+	operatorConfigClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	secretsGetter corev1client.SecretsGetter,
+	configMapsGetter corev1client.ConfigMapsGetter,
+	eventRecorder events.Recorder,
+) *ResourceSyncController {
+	c := &ResourceSyncController{
+		name:                 "ResourceSyncController",
+		operatorConfigClient: operatorConfigClient,
+
+		configMapSyncRules:         map[ResourceLocation]ResourceLocation{},
+		secretSyncRules:            map[ResourceLocation]ResourceLocation{},
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
+
+		configMapGetter: configMapsGetter,
+		secretGetter:    secretsGetter,
+		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
+	}
+
+	informers := []factory.Informer{
+		operatorConfigClient.Informer(),
+	}
+	for namespace := range kubeInformersForNamespaces.Namespaces() {
+		if len(namespace) == 0 {
+			continue
+		}
+		informer := kubeInformersForNamespaces.InformersFor(namespace)
+		informers = append(informers, informer.Core().V1().ConfigMaps().Informer())
+		informers = append(informers, informer.Core().V1().Secrets().Informer())
+	}
+
+	f := factory.New().WithSync(c.Sync).WithSyncContext(c.syncCtx).WithInformers(informers...).ResyncEvery(time.Second).ToController(c.name, eventRecorder.WithComponentSuffix("resource-sync-controller"))
+	c.runFn = f.Run
+
+	return c
+}
+
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.runFn(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return c.name
+}
+
+func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.configMapSyncRules[destination] = source
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.secretSyncRules[destination] = source
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	c.syncRuleLock.RLock()
+	defer c.syncRuleLock.RUnlock()
+
+	errors := []error{}
+
+	for destination, source := range c.configMapSyncRules {
+		if source == emptyResourceLocation {
+			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
+			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncConfigMap(c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	for destination, source := range c.secretSyncRules {
+		if source == emptyResourceLocation {
+			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
+			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.secretGetter.Secrets(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncSecret(c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		cond := operatorv1.OperatorCondition{
+			Type:    condition.ResourceSyncControllerDegradedConditionType,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "Error",
+			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
+		}
+		if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+			return updateError
+		}
+		return nil
+	}
+
+	cond := operatorv1.OperatorCondition{
+		Type:   condition.ResourceSyncControllerDegradedConditionType,
+		Status: operatorv1.ConditionFalse,
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+	return nil
+}
+
+func NewDebugHandler(controller *ResourceSyncController) http.Handler {
+	return &debugHTTPHandler{controller: controller}
+}
+
+type debugHTTPHandler struct {
+	controller *ResourceSyncController
+}
+
+type ResourceSyncRule struct {
+	Source      ResourceLocation `json:"source"`
+	Destination ResourceLocation `json:"destination"`
+}
+
+type ResourceSyncRuleList []ResourceSyncRule
+
+func (l ResourceSyncRuleList) Len() int      { return len(l) }
+func (l ResourceSyncRuleList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l ResourceSyncRuleList) Less(i, j int) bool {
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) > 0 {
+		return false
+	}
+	if strings.Compare(l[i].Source.Name, l[j].Source.Name) < 0 {
+		return true
+	}
+	return false
+}
+
+type ControllerSyncRules struct {
+	Secrets ResourceSyncRuleList `json:"secrets"`
+	Configs ResourceSyncRuleList `json:"configs"`
+}
+
+// ServeSyncRules provides a handler function to return the sync rules of the controller
+func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
+
+	h.controller.syncRuleLock.RLock()
+	defer h.controller.syncRuleLock.RUnlock()
+	syncRules.Secrets = append(syncRules.Secrets, resourceSyncRuleList(h.controller.secretSyncRules)...)
+	syncRules.Configs = append(syncRules.Configs, resourceSyncRuleList(h.controller.configMapSyncRules)...)
+
+	data, err := json.Marshal(syncRules)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}
+
+func resourceSyncRuleList(syncRules map[ResourceLocation]ResourceLocation) ResourceSyncRuleList {
+	rules := make(ResourceSyncRuleList, 0, len(syncRules))
+	for src, dest := range syncRules {
+		rule := ResourceSyncRule{
+			Source:      src,
+			Destination: dest,
+		}
+		rules = append(rules, rule)
+	}
+	sort.Sort(rules)
+	return rules
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,6 +187,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
+github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
 github.com/openshift/library-go/pkg/serviceability


### PR DESCRIPTION
Manila moves to openshift-manila-csi-driver to keep compatibility with old OLM-based operator. Make sure that all objects have the same objects and same selectors as the OLM-based ones, so the new operator can adopt OLM Deployment/DaemonSets.

@openshift/storage 