### PR TITLE
Bug 1863056: Allow the driver to run on any node

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -19,8 +19,7 @@ spec:
       serviceAccount: manila-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:

--- a/assets/node_nfs.yaml
+++ b/assets/node_nfs.yaml
@@ -19,8 +19,7 @@ spec:
       serviceAccount: manila-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -341,8 +341,7 @@ spec:
       serviceAccount: manila-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:
@@ -475,8 +474,7 @@ spec:
       serviceAccount: manila-csi-driver-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:


### PR DESCRIPTION
So masters and other tainted nodes can use PVCs.