### PR TITLE
Bug 1867735: Fix sync of openshift-config/cloud-provider-config ConfigMap

### DIFF
--- a/manifests/05_clusterrole.yaml
+++ b/manifests/05_clusterrole.yaml
@@ -11,15 +11,23 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+
+# The operator needs these config maps:
+# - read/write openshift-manila-csi-driver/cloud-provider-config
+# - read-only kube-system/extension-apiserver-authentication
+# - read/write manila-csi-driver-operator-lock
 - apiGroups:
   - ''
-  resourceNames:
-  - extension-apiserver-authentication
-  - manila-csi-driver-operator-lock
   resources:
   - configmaps
   verbs:
-  - '*'
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/manifests/05_clusterrole.yaml
+++ b/manifests/05_clusterrole.yaml
@@ -76,6 +76,10 @@ rules:
   - get
   - list
   - watch
+  # For CA certificate sync
+  - create
+  - patch
+  - update
 - apiGroups:
   - ''
   resources:
@@ -211,6 +215,18 @@ rules:
   - update
   - delete
 - apiGroups:
+  - csi.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
   - config.openshift.io
   resources:
   - infrastructures
@@ -221,18 +237,7 @@ rules:
 - apiGroups:
   - operator.openshift.io
   resources:
-  - clustercsidrivers
+  - 'clustercsidrivers'
+  - 'clustercsidrivers/status'
   verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - operator.openshift.io
-  resources:
-  - clustercsidrivers/status
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - update
+  - '*'

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -38,7 +38,7 @@ const (
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
 	kubeClient := kubeclient.NewForConfigOrDie(rest.AddUserAgent(controllerConfig.KubeConfig, operatorName))
-	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperandNamespace, "")
+	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperandNamespace, util.CloudConfigNamespace, "")
 
 	dynamicClient, err := dynamic.NewForConfig(controllerConfig.KubeConfig)
 	if err != nil {
@@ -120,7 +120,9 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeClient.CoreV1(),
 		kubeClient.CoreV1(),
 		controllerConfig.EventRecorder)
-	certController.SyncConfigMap(dstConfigMap, srcConfigMap)
+	if err := certController.SyncConfigMap(dstConfigMap, srcConfigMap); err != nil {
+		return err
+	}
 
 	openstackClient, err := manila.NewOpenStackClient(util.CloudConfigFilename, kubeInformersForNamespaces)
 	if err != nil {


### PR DESCRIPTION
Fixed sync of openshift-config/cloud-provider-config into the driver namespace and add the operator enough permissions to actually do that.

Sync RBAC from CSO here, because it has been tested more in CSO.
