### PR TITLE
Bug 1869504: base storageclass names on lower case

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -2,6 +2,7 @@ package manila
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -143,7 +144,7 @@ func (c *ManilaController) applyStorageClass(ctx context.Context, expected *stor
 }
 
 func (c *ManilaController) generateStorageClass(shareType sharetypes.ShareType) *storagev1.StorageClass {
-	storageClassName := util.StorageClassNamePrefix + shareType.Name
+	storageClassName := util.StorageClassNamePrefix + strings.ToLower(shareType.Name)
 	delete := corev1.PersistentVolumeReclaimDelete
 	immediate := storagev1.VolumeBindingImmediate
 	sc := &storagev1.StorageClass{


### PR DESCRIPTION
Now, when we generate storageclass names we use a prefix followed by manila share type names. Unfortunately storageclass names can't contain uppercase characters, which is possible for manila share types. As a result of this, we get errors when deploying the driver.

To prevent the issue we preliminary convert manila share type names to lowercase.