### PR TITLE
Bug 1871999: Allow controller and DaemonSets to run on master nodes

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -16,11 +16,16 @@ spec:
         app: openstack-manila-csi
         component: controllerplugin
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       serviceAccount: manila-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -46,9 +46,14 @@ spec:
           mountPath: /usr/share/pki/ca-trust-source
       priorityClassName: system-cluster-critical
       serviceAccountName: manila-csi-driver-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"
       resources:
         requests:
           cpu: 10m

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -86,11 +86,16 @@ spec:
         app: openstack-manila-csi
         component: controllerplugin
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       serviceAccount: manila-csi-driver-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}


### PR DESCRIPTION
This should allow the manilla controller to run on the master nodes. It still needs to be tested for confirmation.