### PR TITLE
Bug 1868339:     Use the CredentialsRequest created by CVO

### DIFF
--- a/pkg/controllers/secret/secretsync.go
+++ b/pkg/controllers/secret/secretsync.go
@@ -44,8 +44,8 @@ func NewSecretSyncController(
 	resync time.Duration,
 	eventRecorder events.Recorder) factory.Controller {
 
-	// Produce secrets in the operand namespace
-	secretInformer := informers.InformersFor(util.OperandNamespace)
+	// Read secret from operator namespace and save the translated one to the operand namespace
+	secretInformer := informers.InformersFor(util.OperatorNamespace)
 	c := &SecretSyncController{
 		operatorClient: operatorClient,
 		kubeClient:     kubeClient,
@@ -67,7 +67,7 @@ func (c *SecretSyncController) sync(ctx context.Context, syncCtx factory.SyncCon
 		return nil
 	}
 
-	cloudSecret, err := c.secretLister.Secrets(util.OperandNamespace).Get(util.CloudCredentialSecretName)
+	cloudSecret, err := c.secretLister.Secrets(util.OperatorNamespace).Get(util.CloudCredentialSecretName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// TODO: report error after some while?

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -37,7 +37,7 @@ const (
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
 	kubeClient := kubeclient.NewForConfigOrDie(rest.AddUserAgent(controllerConfig.KubeConfig, operatorName))
-	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperandNamespace, util.CloudConfigNamespace, "")
+	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperatorNamespace, util.OperandNamespace, util.CloudConfigNamespace, "")
 
 	// Create GenericOperatorclient. This is used by controllers created down below
 	gvr := operatorapi.SchemeGroupVersion.WithResource("clustercsidrivers")

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -1,6 +1,7 @@
 package util
 
 const (
+	OperatorNamespace         = "openshift-cluster-csi-drivers"
 	OperandNamespace          = "openshift-manila-csi-driver"
 	CloudCredentialSecretName = "manila-cloud-credentials"
 	ManilaSecretName          = "csi-manila-secrets"


### PR DESCRIPTION
Since commit 44d79d3281, we are no longer creating the CredentialsRequest in this operator, but we're relying on CVO to create it. However, we were previously creating 2 CRs: 1 in this operator (for the CSI driver) and another one in CSO (for the this operator itself).

Since now we can only create CRs in CVO, instead of creating 2 different CRs like we were doing before, we're creating only 1 and using it for both this operator and the CSI driver.

CC @openshift/storage 