### PR TITLE
Bug 1876791: Update RBAC of the external-provisioner

### DIFF
--- a/assets/rbac/provisioner_role.yaml
+++ b/assets/rbac/provisioner_role.yaml
@@ -21,3 +21,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -658,6 +658,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
 `)
 
 func rbacProvisioner_roleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
As result of the external-provisioner rebase to v2.0.0, it now needs VolumeAttachment read-only access.