### PR TITLE
Bug 1878980: Use hostNetwork for the NFS CSI driver

### DIFF
--- a/pkg/controller/maniladriver/nfs_nodeplugin.go
+++ b/pkg/controller/maniladriver/nfs_nodeplugin.go
@@ -86,6 +86,7 @@ func generateNFSNodePluginManifest() *appsv1.DaemonSet {
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "csi-nodeplugin",
+					HostNetwork:        true,
 					Containers: []corev1.Container{
 						{
 							Name:  "nfs",


### PR DESCRIPTION
The NFS driver should use hostNetwork to use `clientAddr=<node IP address>` instead of (randomized) Pod IP address.

See https://bugzilla.redhat.com/show_bug.cgi?id=1878980.

@openshift/storage @Fedosin 