### PR TITLE
Bug 1869590: base storageclass names on lower case

### DIFF
--- a/pkg/controller/maniladriver/manila_storageclasses.go
+++ b/pkg/controller/maniladriver/manila_storageclasses.go
@@ -2,6 +2,7 @@ package maniladriver
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
@@ -31,7 +32,7 @@ func (r *ReconcileManilaDriver) handleManilaStorageClasses(instance *maniladrive
 }
 
 func (r *ReconcileManilaDriver) handleManilaStorageClass(instance *maniladriverv1alpha1.ManilaDriver, shareType sharetypes.ShareType, reqLogger logr.Logger) error {
-	storageClassName := storageClassNamePrefix + shareType.Name
+	storageClassName := storageClassNamePrefix + strings.ToLower(shareType.Name)
 	reqLogger.Info("Reconciling Manila StorageClass", "StorageClass.Name", storageClassName)
 
 	// Define a new StorageClass object


### PR DESCRIPTION
This is backport of https://github.com/openshift/csi-driver-manila-operator/pull/52.  See https://bugzilla.redhat.com/show_bug.cgi?id=1869590

Now, when we generate storageclass names we use a prefix followed by manila share type names. Unfortunately storageclass names can't contain uppercase characters, which is possible for manila share types. As a result of this, we get errors when deploying the driver.

To prevent the issue we preliminary convert manila share type names to lowercase.

@openshift/storage @Fedosin 