### PR TITLE
Bug 1880896: Replace cert authority path from clouds.yaml

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -57,7 +57,7 @@ spec:
             - name: socket-dir
               mountPath: /plugin
             - name: cacert
-              mountPath: /usr/share/pki/ca-trust-source
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           resources:
             requests:
               cpu: 10m
@@ -129,7 +129,8 @@ spec:
         - name: socket-dir
           emptyDir: {}
         - name: cacert
-          # Extract ca-bundle.pem to /usr/share/pki/ca-trust-source if present.
+          # If present, extract ca-bundle.pem to
+          # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           # Let the pod start when the ConfigMap does not exist or the certificate
           # is not preset there. The certificate file will be created once the
           # ConfigMap is created / the cerificate is added to it.

--- a/pkg/controllers/secret/secretsync.go
+++ b/pkg/controllers/secret/secretsync.go
@@ -35,6 +35,8 @@ const (
 	cloudSecretKey = "clouds.yaml"
 	// Name of OpenStack in clouds.yaml
 	cloudName = "openstack"
+	// Canonical path for custom ca certificates
+	cacertPath = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
 )
 
 func NewSecretSyncController(
@@ -145,7 +147,8 @@ func (c *SecretSyncController) translateSecret(cloudSecret *v1.Secret) (*v1.Secr
 		data["os-domainName"] = []byte(cloud.AuthInfo.UserDomainName)
 	}
 	if cloud.CACertFile != "" {
-		data["os-certAuthorityPath"] = []byte(cloud.CACertFile)
+		// Replace the original cert authority path from clouds.yaml with the canonical one
+		data["os-certAuthorityPath"] = []byte(cacertPath)
 	}
 
 	secret := v1.Secret{

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -126,7 +126,7 @@ spec:
             - name: socket-dir
               mountPath: /plugin
             - name: cacert
-              mountPath: /usr/share/pki/ca-trust-source
+              mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           resources:
             requests:
               cpu: 10m
@@ -198,7 +198,8 @@ spec:
         - name: socket-dir
           emptyDir: {}
         - name: cacert
-          # Extract ca-bundle.pem to /usr/share/pki/ca-trust-source if present.
+          # If present, extract ca-bundle.pem to
+          # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
           # Let the pod start when the ConfigMap does not exist or the certificate
           # is not preset there. The certificate file will be created once the
           # ConfigMap is created / the cerificate is added to it.


### PR DESCRIPTION
This patch mounts custom ca cert bundle into the predifined location:
/etc/kubernetes/static-pod-resources/configmaps/cloud-config
And forces the driver's controller to take the bundle from this location only.