### PR TITLE
Updating csi-driver-manila-operator builder & base images to be consistent with ART

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7
 COPY . /go/src/github.com/openshift/csi-driver-manila-operator
 RUN cd /go/src/github.com/openshift/csi-driver-manila-operator && \
     go build -mod vendor -o csi-driver-manila-operator cmd/csi-driver-manila-operator/main.go
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 ENV OPERATOR=/usr/local/bin/csi-driver-manila-operator \
     USER_UID=1001 \


### PR DESCRIPTION
Updating csi-driver-manila-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/csi-driver-manila-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.