### PR TITLE
Bug 1894025: Add annotation to operand's namespace

### DIFF
--- a/assets/namespace.yaml
+++ b/assets/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-manila-csi-driver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    openshift.io/node-selector: ""

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -279,6 +279,9 @@ var _namespaceYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-manila-csi-driver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    openshift.io/node-selector: ""
 `)
 
 func namespaceYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This PR is a complement of https://github.com/openshift/cluster-storage-operator/pull/100.

The namespace used by Manila CSI driver is different from other CSI drivers (for backwards compatibility reasons), and it's created by the Manila operator (rather than CVO/CSO, as the other CSI drivers).

CC @openshift/storage
