### PR TITLE
Bug 1917587: disable Manila operator in case of 403 error

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -97,6 +97,9 @@ func (c *ManilaController) sync(ctx context.Context, syncCtx factory.SyncContext
 	shareTypes, err := c.openStackClient.GetShareTypes()
 	if err != nil {
 		switch err.(type) {
+		case gophercloud.ErrDefault403:
+			// User doesn't have permissions to list share types, report the operator as disabled
+			return c.setDisabledCondition("User doesn't have access to Manila service")
 		case *gophercloud.ErrEndpointNotFound:
 			// OpenStack does not support manila, report the operator as disabled
 			return c.setDisabledCondition("This OpenStack cluster does not provide Manila service")


### PR DESCRIPTION
Now when user doesn't have permissions to list share types, Manila returns 403 error, and the operator becomes Degraded blocking upgrades.

This commit prevents this situation and disables the operator if 403 error was returned.