### PR TITLE
Bug 1918716: increase Keystone timeout to 2 minutes

### DIFF
--- a/pkg/controllers/manila/openstack.go
+++ b/pkg/controllers/manila/openstack.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -74,6 +75,8 @@ func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
 		}
 		provider.HTTPClient = client
 	}
+
+	provider.HTTPClient.Timeout = 120 * time.Second
 
 	err = openstack.Authenticate(provider, *opts)
 	if err != nil {


### PR DESCRIPTION
Current timeout is set to 30 seconds, but sometimes Keystone is too slow to respond within this time, and the operator becomes degraded.

To mitigate this behavior we increase the timeout to 2 minutes.