### PR TITLE
[release-4.6] Bug 1918367: Make Manila operator more tolerant

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -97,6 +97,9 @@ func (c *ManilaController) sync(ctx context.Context, syncCtx factory.SyncContext
 	shareTypes, err := c.openStackClient.GetShareTypes()
 	if err != nil {
 		switch err.(type) {
+		case gophercloud.ErrDefault403:
+			// User doesn't have permissions to list share types, report the operator as disabled
+			return c.setDisabledCondition("User doesn't have access to Manila service")
 		case *gophercloud.ErrEndpointNotFound:
 			// OpenStack does not support manila, report the operator as disabled
 			return c.setDisabledCondition("This OpenStack cluster does not provide Manila service")


### PR DESCRIPTION
This is a manual cherry-pick of #81 and #84.

The changes allow Manila operator to tolerate 403 and 404 errors, that would otherwise cause the operator and the whole cluster to enter a degraded state. We now disable the Manila operator on 403 and 404 errors.

This PR also add more debugging info.