### PR TITLE
Cleanup: Remove serviceName from controller manifest

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -10,7 +10,6 @@ spec:
     matchLabels:
       app: openstack-manila-csi
       component: controllerplugin
-  serviceName: manila-csi-driver-controller
   replicas: 1
   template:
     metadata:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -79,7 +79,6 @@ spec:
     matchLabels:
       app: openstack-manila-csi
       component: controllerplugin
-  serviceName: manila-csi-driver-controller
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Deployment spec doesn't support this property, so we should remove it.