### PR TITLE
Bug 1933184: Add maxUnavailable to DaemonSets

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -10,6 +10,10 @@ spec:
     matchLabels:
       app: openstack-manila-csi
       component: nodeplugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/assets/node_nfs.yaml
+++ b/assets/node_nfs.yaml
@@ -8,6 +8,10 @@ spec:
     matchLabels:
       app: openstack-manila-csi
       component: nfs-nodeplugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -312,6 +312,10 @@ spec:
     matchLabels:
       app: openstack-manila-csi
       component: nodeplugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:
@@ -445,6 +449,10 @@ spec:
     matchLabels:
       app: openstack-manila-csi
       component: nfs-nodeplugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
To speed up cluster upgrade by allowing more nodes to be updated
simultaneously.