### PR TITLE
Bug 1949357: Fix namespace in metrics collection objects

### DIFF
--- a/assets/rbac/kube_rbac_proxy_binding.yaml
+++ b/assets/rbac/kube_rbac_proxy_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-kube-rbac-proxy-role

--- a/assets/rbac/prometheus_role.yaml
+++ b/assets/rbac/prometheus_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manila-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 rules:
 - apiGroups:
   - ""

--- a/assets/rbac/prometheus_rolebinding.yaml
+++ b/assets/rbac/prometheus_rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manila-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/assets/service.yaml
+++ b/assets/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: manila-csi-driver-controller-metrics
   name: manila-csi-driver-controller-metrics
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   ports:
   - name: provisioner-m

--- a/assets/servicemonitor.yaml
+++ b/assets/servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: manila-csi-driver-controller-monitor
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -12,7 +12,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: manila-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+      serverName: manila-csi-driver-controller-metrics.openshift-manila-csi-driver.svc
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
     path: /metrics
@@ -20,7 +20,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: manila-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+      serverName: manila-csi-driver-controller-metrics.openshift-manila-csi-driver.svc
   jobLabel: component
   selector:
     matchLabels:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -627,7 +627,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: manila-csi-driver-controller-sa
-    namespace: openshift-cluster-csi-drivers
+    namespace: openshift-manila-csi-driver
 roleRef:
   kind: ClusterRole
   name: manila-kube-rbac-proxy-role
@@ -738,7 +738,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manila-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 rules:
 - apiGroups:
   - ""
@@ -772,7 +772,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manila-csi-driver-prometheus
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -962,7 +962,7 @@ metadata:
   labels:
     app: manila-csi-driver-controller-metrics
   name: manila-csi-driver-controller-metrics
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   ports:
   - name: provisioner-m
@@ -998,7 +998,7 @@ var _servicemonitorYaml = []byte(`apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: manila-csi-driver-controller-monitor
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -1008,7 +1008,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: manila-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+      serverName: manila-csi-driver-controller-metrics.openshift-manila-csi-driver.svc
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
     path: /metrics
@@ -1016,7 +1016,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: manila-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+      serverName: manila-csi-driver-controller-metrics.openshift-manila-csi-driver.svc
   jobLabel: component
   selector:
     matchLabels:


### PR DESCRIPTION
Use the manila namespace instead of `openshift-cluster-csi-drivers`.