### PR TITLE
Bug 1820238: add cluster id to share metadata

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -37,6 +37,7 @@ spec:
               cpu: 10m
           args:
             - --v=${LOG_LEVEL}
+            - --cluster-id=${CLUSTER_ID}
             - --nodeid=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --drivername=$(DRIVER_NAME)

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -112,6 +112,7 @@ spec:
               cpu: 10m
           args:
             - --v=${LOG_LEVEL}
+            - --cluster-id=${CLUSTER_ID}
             - --nodeid=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --drivername=$(DRIVER_NAME)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -96,7 +96,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		"controller.yaml",
 		kubeClient,
 		kubeInformersForNamespaces.InformersFor(util.OperandNamespace),
-		nil,
+		configInformers,
 		csidrivercontrollerservicecontroller.WithObservedProxyDeploymentHook(),
 	).WithCSIDriverNodeService(
 		"ManilaDriverNodeServiceController",


### PR DESCRIPTION
In https://github.com/kubernetes/cloud-provider-openstack/pull/1459 we added a possibility to append share metadata with cluster id specified by "--cluster-id" argument.

This commit starts using this feature in the operator.