### PR TITLE
Create CI image for Manila CSI Operator testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,6 @@ anaconda-mode/
 *.dll
 *.so
 *.dylib
-# Test binary, build with 'go test -c'
-*.test
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 ### Vim ###

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,5 @@
+# "src" is build by a prow job when building final images.
+# It contains full repository sources + jq + pyhon with yaml module.
+# Use it as test image for the operator.
+
+FROM src


### PR DESCRIPTION
Add a basic Dockerfile.test that was largely inspired by the one in the
Cinder CSI operator.
We also had to change the .gitignore to remove "*.text" entry.

Part of [OSASINFRA-2494](https://issues.redhat.com/browse/OSASINFRA-2494).
