### PR TITLE
Generate default volumesnapshotclass for Manila CSI driver

### DIFF
--- a/assets/volumesnapshotclass.yaml
+++ b/assets/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-manila-standard
+driver: manila.csi.openstack.org
+deletionPolicy: Delete
+parameters:
+  force-create: "false"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
 
-	// csidrivercontroller "github.com/openshift/library-go/pkg/operator/csi/csidrivercontroller"
 	goc "github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -76,6 +75,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"controller_sa.yaml",
 			"node_sa.yaml",
 			"service.yaml",
+			"volumesnapshotclass.yaml",
 			"rbac/snapshotter_binding.yaml",
 			"rbac/snapshotter_role.yaml",
 			"rbac/provisioner_binding.yaml",


### PR DESCRIPTION
This commit allows the operator to create a default volumesnapshotclass for Manila CSI driver.