### PR TITLE
Bug 1960152: Use cluster Proxy when available

### DIFF
--- a/pkg/controllers/manila/openstack.go
+++ b/pkg/controllers/manila/openstack.go
@@ -68,6 +68,7 @@ func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
 		certPool.AppendCertsFromPEM(cert)
 		client := http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					RootCAs: certPool,
 				},


### PR DESCRIPTION
Even though the proxy env vars are available
they are not used when attempting to connect
to the OSP clouds through the proxy. This commit
fixes the issue by ensuring those env vars are
used when available.