### PR TITLE
Bug 1991814: Move namespace creation to cluster-storage-operator

### DIFF
--- a/assets/namespace.yaml
+++ b/assets/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-manila-csi-driver
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    openshift.io/node-selector: ""

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -72,7 +72,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces,
 		assets.ReadFile,
 		[]string{
-			"namespace.yaml",
 			"csidriver.yaml",
 			"controller_sa.yaml",
 			"controller_pdb.yaml",


### PR DESCRIPTION
The namespace must exist to compose correct RelatedObjects in CSO.
See https://github.com/openshift/cluster-storage-operator/pull/202 for details.