### PR TITLE
Bug 2001620: Do not degrade cluster on failure to reach Manila

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -2,11 +2,10 @@ package manila
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"strings"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/csi-driver-manila-operator/pkg/util"
@@ -96,26 +95,9 @@ func (c *ManilaController) sync(ctx context.Context, syncCtx factory.SyncContext
 		return nil
 	}
 
-	var err403 gophercloud.ErrDefault403
-	var errNoEndpoint *gophercloud.ErrEndpointNotFound
 	shareTypes, err := c.openStackClient.GetShareTypes()
 	if err != nil {
-		switch {
-		case errors.As(err, &err403):
-			// User doesn't have permissions to list share types, report the operator as disabled
-			klog.V(4).Infof("User doesn't have access to Manila service: %v", err)
-			return c.setDisabledCondition("User doesn't have access to Manila service")
-		case isNotFoundError(err):
-			// Manila Share Type API is not available
-			klog.V(4).Infof("Cannot find API to fetch Manila share types: %v", err)
-			return c.setDisabledCondition("Cannot find API to fetch Manila share types")
-		case errors.As(err, &errNoEndpoint):
-			// OpenStack does not support manila, report the operator as disabled
-			klog.V(4).Infof("This OpenStack cluster does not provide Manila service: %v", err)
-			return c.setDisabledCondition("This OpenStack cluster does not provide Manila service")
-		default:
-			return err
-		}
+		return c.setDisabledCondition(fmt.Sprintf("Unable to retrieve Manila share types: %v", err))
 	}
 
 	if len(shareTypes) == 0 {
@@ -210,13 +192,4 @@ func removeConditionFn(cnd string) v1helpers.UpdateStatusFunc {
 		v1helpers.RemoveOperatorCondition(&oldStatus.Conditions, cnd)
 		return nil
 	}
-}
-
-func isNotFoundError(err error) bool {
-	var errNotFound gophercloud.ErrResourceNotFound
-	var pErrNotFound *gophercloud.ErrResourceNotFound
-	var errDefault404 gophercloud.ErrDefault404
-	var pErrDefault404 *gophercloud.ErrDefault404
-
-	return errors.As(err, &errNotFound) || errors.As(err, &pErrNotFound) || errors.As(err, &errDefault404) || errors.As(err, &pErrDefault404)
 }


### PR DESCRIPTION
It's possible that for one reason or another we're unable to reach the
Manila endpoint. In the past we've tried to be smart and handled errors
differently, if it's a 404, a 403, or other types of errors. The
problem with this approach is that it's very easy to forget valid
failure cases. We've had a recent example with proxy setting not
correctly propagated to the Manila pod and degrading the cluster.

We should instead treat all failures to reach the Manila endpoint as
a non fatal error and disable the Manila operator instead of making the
cluster degraded.

This makes the Manila operator consistent with the EFS one.