### PR TITLE
Updating csi-driver-manila-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.16-openshift-4.10
+  tag: rhel-8-release-golang-1.17-openshift-4.10

--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10
 COPY . /go/src/github.com/openshift/csi-driver-manila-operator
 RUN cd /go/src/github.com/openshift/csi-driver-manila-operator && \
     go build -mod vendor -o csi-driver-manila-operator cmd/csi-driver-manila-operator/main.go

--- a/pkg/dependencymagnet/dependencymagnet.go
+++ b/pkg/dependencymagnet/dependencymagnet.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // go mod won't pull in code that isn't depended upon, but we have some code we don't depend on from code that must be included


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/5b89f5b601508a0bcc0399fd3f34b7aa2e86e90e/images/csi-driver-manila-operator.yml
Replaces https://github.com/openshift/csi-driver-manila-operator/pull/129
/cc @openshift/storage 