### PR TITLE
Normalize the storage class name when ShareType has invalid characters

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -142,7 +142,10 @@ func (c *ManilaController) applyStorageClass(ctx context.Context, expected *stor
 }
 
 func (c *ManilaController) generateStorageClass(shareType sharetypes.ShareType) *storagev1.StorageClass {
-	storageClassName := util.StorageClassNamePrefix + strings.ToLower(shareType.Name)
+	/* As per RFC 1123 the storage class name must consist of lower case alphanumeric character,  '-' or '.'
+	   and must start and end with an alphanumeric character.
+	*/
+	storageClassName := util.StorageClassNamePrefix + strings.ToLower(strings.Replace(shareType.Name, "_", "-", -1))
 	delete := corev1.PersistentVolumeReclaimDelete
 	immediate := storagev1.VolumeBindingImmediate
 	sc := &storagev1.StorageClass{


### PR DESCRIPTION
It's possible that an operator creates a Manila share type containing "_"
characters in the name, which are invalid in the kubernetes context [1].
Instead of failing and workaround it on the OpenStack side (e.g., rename
the Share type name), this patch just normalize the storage class name
using the allowed format, maintaining the right "type" metadata to make
sure the CSI driver is able to resolve the share type capabilities when
a pvc is created.

Fixes #43

[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

Signed-off-by: Francesco Pantano <fpantano@redhat.com>