### PR TITLE
ci: enable more tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -14,3 +14,14 @@ DriverInfo:
   SupportedSizeRange:
     Min: 1Gi
     Max: 16Ti
+  Capabilities:
+    persistence: true
+    # our CI uses CephFS / NFS driver, which doesn't support fsgroups.
+    fsGroup: false
+    exec: true
+    # our CI uses CephFS / NFS driver, which doesn't support snapshots.
+    # The driver supports snapshots in the wallaby release of OpenStack
+    # Manila with Ceph Octopus+.
+    snapshotDataSource: false
+    multipods: true
+    RWX: true


### PR DESCRIPTION
More tests could be run, let's just enable them in the e2e manifest.
