### PR TITLE
Expose CSI_FSGROUP_POLICY as an operator option

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -8,3 +8,4 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: false
+  fsGroupPolicy: None

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -38,6 +38,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: CSI_FSGROUP_POLICY
+          value: None
         image: quay.io/openshift/origin-csi-driver-manila-operator:latest
         imagePullPolicy: IfNotPresent
         name: manila-csi-driver-operator

--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -3,15 +3,18 @@ package manila
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/csi-driver-manila-operator/assets"
 	"github.com/openshift/csi-driver-manila-operator/pkg/util"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -41,6 +44,7 @@ type ManilaController struct {
 	kubeClient         kubernetes.Interface
 	openStackClient    *openStackClient
 	storageClassLister storagelisters.StorageClassLister
+	csiDriverLister    storagelisters.CSIDriverLister
 	// Controllers to start when Manila is detected
 	csiControllers     []Runnable
 	controllersRunning bool
@@ -69,10 +73,12 @@ func NewManilaController(
 	eventRecorder events.Recorder) factory.Controller {
 
 	scInformer := informers.InformersFor("").Storage().V1().StorageClasses()
+	csiInformer := informers.InformersFor("").Storage().V1().CSIDrivers()
 	c := &ManilaController{
 		operatorClient:     operatorClient,
 		kubeClient:         kubeClient,
 		storageClassLister: scInformer.Lister(),
+		csiDriverLister:    csiInformer.Lister(),
 		openStackClient:    openStackClient,
 		csiControllers:     csiControllers,
 		eventRecorder:      eventRecorder.WithComponentSuffix("ManilaController"),
@@ -80,6 +86,7 @@ func NewManilaController(
 	return factory.New().WithSync(c.sync).WithSyncDegradedOnError(operatorClient).ResyncEvery(resyncInterval).WithInformers(
 		operatorClient.Informer(),
 		scInformer.Informer(),
+		csiInformer.Informer(),
 	).ToController("ManilaController", eventRecorder)
 }
 
@@ -115,12 +122,60 @@ func (c *ManilaController) sync(ctx context.Context, syncCtx factory.SyncContext
 		}
 		c.controllersRunning = true
 	}
+
+	err = c.syncCSIDriver(ctx)
+	if err != nil {
+		return err
+	}
+
 	err = c.syncStorageClasses(ctx, shareTypes)
 	if err != nil {
 		return err
 	}
 
 	return c.setEnabledCondition(ctx)
+}
+
+func (c *ManilaController) getFsGroupPolicy(ctx context.Context) storagev1.FSGroupPolicy {
+
+	// NOTE: Set the fsGroupPolicy param to None as default value
+	fsGroupPolicy := storagev1.NoneFSGroupPolicy
+
+	fsGroupPolicyFromEnv := storagev1.FSGroupPolicy(os.Getenv("CSI_FSGROUP_POLICY"))
+	switch fsGroupPolicyFromEnv {
+	case storagev1.NoneFSGroupPolicy, storagev1.FileFSGroupPolicy, storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy:
+		fsGroupPolicy = fsGroupPolicyFromEnv
+	default:
+		if fsGroupPolicyFromEnv != "" {
+			klog.V(4).Infof("Invalid CSI_FSGROUP_POLICY %q. Ignoring.", fsGroupPolicyFromEnv)
+		}
+	}
+
+	return fsGroupPolicy
+}
+
+func (c *ManilaController) syncCSIDriver(ctx context.Context) error {
+	klog.V(4).Infof("Starting CSI driver config refresh")
+	defer klog.V(4).Infof("CSI driver config refresh finished")
+
+	var errs []error
+
+	stream, e := assets.ReadFile("csidriver.yaml")
+	if e != nil {
+		panic("Error loading the CSIDriver resource")
+	}
+
+	cr := resourceread.ReadCSIDriverV1OrDie(stream)
+	f := c.getFsGroupPolicy(ctx)
+	cr.Spec.FSGroupPolicy = &f
+
+	_, _, err := resourceapply.ApplyCSIDriver(ctx, c.kubeClient.StorageV1(), c.eventRecorder, cr)
+
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return k8serrors.NewAggregate(errs)
 }
 
 func (c *ManilaController) syncStorageClasses(ctx context.Context, shareTypes []sharetypes.ShareType) error {

--- a/pkg/controllers/secret/secretsync.go
+++ b/pkg/controllers/secret/secretsync.go
@@ -34,7 +34,6 @@ const (
 	// Name of key with clouds.yaml in Secret provided by cloud-credentials-operator.
 	cloudSecretKey = "clouds.yaml"
 	// Name of OpenStack in clouds.yaml
-	cloudName = "openstack"
 	// Canonical path for custom ca certificates
 	cacertPath = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
 )
@@ -103,9 +102,9 @@ func (c *SecretSyncController) translateSecret(cloudSecret *v1.Secret) (*v1.Secr
 		return nil, fmt.Errorf("failed to unmarshal clouds credentials stored in secret %s: %s", util.CloudCredentialSecretName, err)
 	}
 
-	cloud, ok := clouds.Clouds[cloudName]
+	cloud, ok := clouds.Clouds[util.CloudName]
 	if !ok {
-		return nil, fmt.Errorf("failed to parse clouds credentials stored in secret %s: cloud %s not found", util.CloudCredentialSecretName, cloudName)
+		return nil, fmt.Errorf("failed to parse clouds credentials stored in secret %s: cloud %s not found", util.CloudCredentialSecretName, util.CloudName)
 	}
 
 	data := cloudToConf(cloud)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -74,7 +74,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces,
 		assets.ReadFile,
 		[]string{
-			"csidriver.yaml",
 			"controller_sa.yaml",
 			"controller_pdb.yaml",
 			"node_sa.yaml",


### PR DESCRIPTION
The operator is now able to configure the CSIDriver object applying a
FsGroupPolicy value defined as input. csidriver.yaml is not a static resource
anymore and the manila driver operator manifest is updated to support this new
option.  The manila controller introduces some logic to dynamically refresh the
CSIDriver resource and, this pattern can be extended for any other option we'd
like to support in the future. The CSI_FSGROUP_POLICY option is defined as an
environment variable for the operator, and it's forced to None if the operator
doesn't make an explicit override.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>