### PR TITLE
Bug 2057637: Include secrets to VolumeSnapshotClass

### DIFF
--- a/assets/volumesnapshotclass.yaml
+++ b/assets/volumesnapshotclass.yaml
@@ -6,3 +6,5 @@ driver: manila.csi.openstack.org
 deletionPolicy: Delete
 parameters:
   force-create: "false"
+  csi.storage.k8s.io/snapshotter-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/snapshotter-secret-namespace: openshift-manila-csi-driver


### PR DESCRIPTION
The manila-csi snapshotter needs to have access to the manila provisioner secrets in order to create snapshots. 
Secrets [0]  are created within the `openshift-manila-csi-driver` namespace [1] and they should be referenced by
the `SnapshotVolumeClass`, which doesn't include them.

[0] https://github.com/openshift/csi-driver-manila-operator/blob/master/pkg/util/const.go#L7
[1] https://github.com/openshift/csi-driver-manila-operator/blob/master/pkg/util/const.go#L5

fixes #139
Signed-off-by: Francesco Pantano <fpantano@redhat.com>