### PR TITLE
Bug 2106736: Add multiplePVsSameID capability

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -25,3 +25,4 @@ DriverInfo:
     snapshotDataSource: false
     multipods: true
     RWX: true
+    multiplePVsSameID: true


### PR DESCRIPTION
This CSI driver can handle multiple PVs that have the same VolumeHandle used on the same node.

cc @openshift/storage