### PR TITLE
OCPBUGS-8683: Add management workloads annotations

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         app: openstack-manila-csi
         component: controllerplugin
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         app: openstack-manila-csi
         component: nodeplugin
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/assets/node_nfs.yaml
+++ b/assets/node_nfs.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         app: openstack-manila-csi
         component: nfs-nodeplugin
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
To support the workload partitioning we need to add the required annotations (openshift/enhancements#703).