### PR TITLE
OCPBUGS-14049: Don't cache OpenStack client

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -42,7 +42,6 @@ import (
 type ManilaController struct {
 	operatorClient     v1helpers.OperatorClient
 	kubeClient         kubernetes.Interface
-	openStackClient    *openStackClient
 	storageClassLister storagelisters.StorageClassLister
 	csiDriverLister    storagelisters.CSIDriverLister
 	// Controllers to start when Manila is detected
@@ -68,7 +67,6 @@ func NewManilaController(
 	operatorClient v1helpers.OperatorClient,
 	kubeClient kubernetes.Interface,
 	informers v1helpers.KubeInformersForNamespaces,
-	openStackClient *openStackClient,
 	csiControllers []Runnable,
 	eventRecorder events.Recorder) factory.Controller {
 
@@ -79,7 +77,6 @@ func NewManilaController(
 		kubeClient:         kubeClient,
 		storageClassLister: scInformer.Lister(),
 		csiDriverLister:    csiInformer.Lister(),
-		openStackClient:    openStackClient,
 		csiControllers:     csiControllers,
 		eventRecorder:      eventRecorder.WithComponentSuffix("ManilaController"),
 	}
@@ -102,7 +99,11 @@ func (c *ManilaController) sync(ctx context.Context, syncCtx factory.SyncContext
 		return nil
 	}
 
-	shareTypes, err := c.openStackClient.GetShareTypes()
+	openstackClient, err := NewOpenStackClient(util.CloudConfigFilename)
+	if err != nil {
+		return c.setDisabledCondition(ctx, fmt.Sprintf("Unable to connect to OpenStack: %v", err))
+	}
+	shareTypes, err := openstackClient.GetShareTypes()
 	if err != nil {
 		return c.setDisabledCondition(ctx, fmt.Sprintf("Unable to retrieve Manila share types: %v", err))
 	}

--- a/pkg/controllers/manila/openstack.go
+++ b/pkg/controllers/manila/openstack.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/csi-driver-manila-operator/pkg/util"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"sigs.k8s.io/yaml"
 )
 
@@ -22,10 +21,7 @@ type openStackClient struct {
 	cloud *clientconfig.Cloud
 }
 
-func NewOpenStackClient(
-	cloudConfigFilename string,
-	informers v1helpers.KubeInformersForNamespaces,
-) (*openStackClient, error) {
+func NewOpenStackClient(cloudConfigFilename string) (*openStackClient, error) {
 	cloud, err := getCloudFromFile(cloudConfigFilename)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -198,11 +198,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		return err
 	}
 
-	openstackClient, err := manila.NewOpenStackClient(util.CloudConfigFilename, kubeInformersForNamespaces)
-	if err != nil {
-		return err
-	}
-
 	secretSyncController := secret.NewSecretSyncController(
 		operatorClient,
 		kubeClient,
@@ -214,7 +209,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		operatorClient,
 		kubeClient,
 		kubeInformersForNamespaces,
-		openstackClient,
 		[]manila.Runnable{
 			csiDriverControllerSet,
 			nfsCSIDriverController,


### PR DESCRIPTION
We are initialising an OpenStack client and storing it as an attribute of `ManilaController`. However, this takes the credentials at the time of client creation. These credentials can change over time, as a result of e.g. password rotation.

We opt to avoid caching the client, creating it each time we need it rather than once during creation of the controller instance. Given the sync interval, the overhead of this should be minimal.
