### PR TITLE
Simplify cloud interaction

### DIFF
--- a/pkg/controllers/manila/manila.go
+++ b/pkg/controllers/manila/manila.go
@@ -99,11 +99,7 @@ func (c *ManilaController) sync(ctx context.Context, syncCtx factory.SyncContext
 		return nil
 	}
 
-	openstackClient, err := NewOpenStackClient(util.CloudConfigFilename)
-	if err != nil {
-		return c.setDisabledCondition(ctx, fmt.Sprintf("Unable to connect to OpenStack: %v", err))
-	}
-	shareTypes, err := openstackClient.GetShareTypes()
+	shareTypes, err := GetShareTypes()
 	if err != nil {
 		return c.setDisabledCondition(ctx, fmt.Sprintf("Unable to retrieve Manila share types: %v", err))
 	}

--- a/pkg/controllers/manila/openstack.go
+++ b/pkg/controllers/manila/openstack.go
@@ -1,97 +1,28 @@
 package manila
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"time"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/csi-driver-manila-operator/pkg/util"
 	"github.com/openshift/csi-driver-manila-operator/pkg/version"
-	"sigs.k8s.io/yaml"
 )
 
-type openStackClient struct {
-	cloud *clientconfig.Cloud
-}
+func GetShareTypes() ([]sharetypes.ShareType, error) {
+	opts := new(clientconfig.ClientOpts)
+	opts.Cloud = util.CloudName
 
-func NewOpenStackClient(cloudConfigFilename string) (*openStackClient, error) {
-	cloud, err := getCloudFromFile(cloudConfigFilename)
+	client, err := clientconfig.NewServiceClient("sharev2", opts)
 	if err != nil {
-		return nil, err
-	}
-	return &openStackClient{
-		cloud: cloud,
-	}, nil
-}
-
-func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
-	clientOpts := new(clientconfig.ClientOpts)
-
-	if o.cloud.AuthInfo != nil {
-		clientOpts.AuthInfo = o.cloud.AuthInfo
-		clientOpts.AuthType = o.cloud.AuthType
-		clientOpts.Cloud = o.cloud.Cloud
-		clientOpts.RegionName = o.cloud.RegionName
-	}
-
-	opts, err := clientconfig.AuthOptions(clientOpts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate auth options: %w", err)
-	}
-
-	provider, err := openstack.NewClient(opts.IdentityEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create a provider client: %w", err)
+		return nil, fmt.Errorf("failed to create shared filesystem client: %w", err)
 	}
 
 	// we represent version using commits since we don't tag releases
 	ua := gophercloud.UserAgent{}
 	ua.Prepend(fmt.Sprintf("csi-driver-manila-operator/%s", version.Get().GitCommit))
-	provider.UserAgent = ua
-
-	cert, err := getCloudProviderCert()
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed to get cloud provider CA certificate: %w", err)
-	}
-
-	if len(cert) > 0 {
-		certPool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("create system cert pool failed: %w", err)
-		}
-		certPool.AppendCertsFromPEM(cert)
-		client := http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{
-					RootCAs: certPool,
-				},
-			},
-		}
-		provider.HTTPClient = client
-	}
-
-	provider.HTTPClient.Timeout = 120 * time.Second
-
-	err = openstack.Authenticate(provider, *opts)
-	if err != nil {
-		return nil, fmt.Errorf("cannot authenticate with given credentials: %w", err)
-	}
-
-	client, err := openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{
-		Region: clientOpts.RegionName,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot find an endpoint for Shared File Systems API v2: %w", err)
-	}
+	client.UserAgent = ua
 
 	allPages, err := sharetypes.List(client, &sharetypes.ListOpts{}).AllPages()
 	if err != nil {
@@ -99,26 +30,4 @@ func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
 	}
 
 	return sharetypes.ExtractShareTypes(allPages)
-}
-
-func getCloudFromFile(filename string) (*clientconfig.Cloud, error) {
-	cloudConfig, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	var clouds clientconfig.Clouds
-	err = yaml.Unmarshal(cloudConfig, &clouds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal clouds credentials from %s: %w", filename, err)
-	}
-
-	cfg, ok := clouds.Clouds[util.CloudName]
-	if !ok {
-		return nil, fmt.Errorf("could not find cloud named %q in credential file %s", util.CloudName, filename)
-	}
-	return &cfg, nil
-}
-
-func getCloudProviderCert() ([]byte, error) {
-	return ioutil.ReadFile(util.CertFile)
 }

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -11,10 +11,6 @@ const (
 
 	StorageClassNamePrefix = "csi-manila-"
 
-	// OpenStack config file name (as present in the operator Deployment)
-	CloudConfigFilename = "/etc/openstack/clouds.yaml"
-	CertFile            = "/etc/openstack-ca/ca-bundle.pem"
-
 	// Name of cloud in secret provided by cloud-credentials-operator
 	CloudName = "openstack"
 )


### PR DESCRIPTION
We were handling the parsing of `cloud.yaml` and creation of HTTP clients ourselves. There's no need to do this as `gophercloud.utils` is more than capable of doing this for us, including handling CA certs and proxies. We know this since this is exactly what we're already doing in openstack-cinder-csi-driver-operator.

WIP while we wait for #184, which this is stacked on top of. I'd also like to validate that things work as expected when using self-signed certificates. I expect that the `clouds.$cloud.cacert` setting should be configured in `clouds.yaml` in this case and things should be copied over, but I need to check.
