### PR TITLE
Configure User Agent

### DIFF
--- a/pkg/controllers/manila/openstack.go
+++ b/pkg/controllers/manila/openstack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/csi-driver-manila-operator/pkg/util"
+	"github.com/openshift/csi-driver-manila-operator/pkg/version"
 	"sigs.k8s.io/yaml"
 )
 
@@ -50,6 +51,11 @@ func (o *openStackClient) GetShareTypes() ([]sharetypes.ShareType, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a provider client: %w", err)
 	}
+
+	// we represent version using commits since we don't tag releases
+	ua := gophercloud.UserAgent{}
+	ua.Prepend(fmt.Sprintf("csi-driver-manila-operator/%s", version.Get().GitCommit))
+	provider.UserAgent = ua
 
 	cert, err := getCloudProviderCert()
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
This can be a helpful breadcrumb when debugging services.

Note that the version information ldflags are populated by [build-machinery-go](https://github.com/openshift/build-machinery-go), which provides e.g. the `build` makefile target.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
