### PR TITLE
Revert "OCPBUGS-14049: Add secret informer"

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -45,7 +45,6 @@ const (
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
 	kubeClient := kubeclient.NewForConfigOrDie(rest.AddUserAgent(controllerConfig.KubeConfig, operatorName))
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, util.OperatorNamespace, util.OperandNamespace, util.CloudConfigNamespace, "")
-	secretInformer := kubeInformersForNamespaces.InformersFor(util.OperatorNamespace).Core().V1().Secrets()
 	configMapInformer := kubeInformersForNamespaces.InformersFor(util.OperandNamespace).Core().V1().ConfigMaps()
 	nodeInformer := kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes()
 
@@ -138,9 +137,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		configInformers,
 		[]factory.Informer{
 			nodeInformer.Informer(),
-			secretInformer.Informer(),
 			configMapInformer.Informer()},
-		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(util.OperatorNamespace, util.CloudCredentialSecretName, secretInformer),
 		csidrivercontrollerservicecontroller.WithObservedProxyDeploymentHook(),
 		csidrivercontrollerservicecontroller.WithCABundleDeploymentHook(
 			util.OperandNamespace,
@@ -155,7 +152,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeClient,
 		kubeInformersForNamespaces.InformersFor(util.OperandNamespace),
 		nil,
-		csidrivernodeservicecontroller.WithSecretHashAnnotationHook(util.OperatorNamespace, util.CloudCredentialSecretName, secretInformer),
 		csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook(),
 		csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
 			util.OperandNamespace,


### PR DESCRIPTION
This reverts commit 705fb00702b19a7af5149ccbea1435b802632a57. The informers are not applied to the affected controller and have no effect. Revert the change to prevent confusion at a later date.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
