### PR TITLE
OCPBUGS-9331: Fix selector for manila-csi-driver-controller-metrics service

### DIFF
--- a/assets/service.yaml
+++ b/assets/service.yaml
@@ -18,6 +18,6 @@ spec:
     protocol: TCP
     targetPort: snapshotter-m
   selector:
-    app: manila-csi-driver-controller
+    app: openstack-manila-csi
   sessionAffinity: None
   type: ClusterIP


### PR DESCRIPTION
The selector was pointing to a non-existing pod and as a result the endpoint was empty. The controller app is named `openstack-manila-csi`.