### PR TITLE
OCPBUGS-29240: Add missing healthchecks

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -74,6 +74,19 @@ spec:
               value: NFS
             - name: FWD_CSI_ENDPOINT
               value: unix:///plugin/csi-nfs.sock
+          ports:
+            - name: healthz
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10306
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
           volumeMounts:
             - name: socket-dir
               mountPath: /plugin
@@ -211,6 +224,22 @@ spec:
           volumeMounts:
           - mountPath: /etc/tls/private
             name: metrics-serving-cert
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=10s
+            - --health-port=10306
+            - --v=${LOG_LEVEL}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -103,6 +103,7 @@ spec:
           args:
             - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
+            - "--http-endpoint=:10307"
             - --kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock
           lifecycle:
             preStop:
@@ -118,11 +119,22 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          ports:
+            - containerPort: 10307
+              name: rhealthz
           resources:
             requests:
               cpu: 5m
               memory: 20Mi
           terminationMessagePolicy: FallbackToLogsOnError
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: rhealthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
         - name: csi-liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -73,6 +73,19 @@ spec:
               mountPath: /etc/selinux
             - name: sys-fs
               mountPath: /sys/fs
+          ports:
+            - name: healthz
+              # Due to hostNetwork, this port is open on all nodes!
+              containerPort: 10305
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
           resources:
             requests:
               cpu: 10m
@@ -110,6 +123,22 @@ spec:
               cpu: 5m
               memory: 20Mi
           terminationMessagePolicy: FallbackToLogsOnError
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=10s
+            - --health-port=10305
+            - --v=${LOG_LEVEL}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: registration-dir
           hostPath:


### PR DESCRIPTION
Add missing healthchecks to Manila CSI driver and node registrar pods, similar to what was done for Cinder CSI in https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/52 and https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/161.